### PR TITLE
Implements the basic functionality in a basic way

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,8 +22,7 @@ lazy val pluginSettings = Seq(
       "jgit-repo" at "http://download.eclipse.org/jgit/maven"
     ),
     libraryDependencies ++= Seq(
-      "org.scalactic"     %% "scalactic"  % "3.0.0",
-      "com.fortysevendeg" %% "github4s"   % "0.9.1-SNAPSHOT",
+      "com.fortysevendeg" %% "github4s"   % "0.10.0",
       "org.scalatest"     %% "scalatest"  % versions("scalatest") % "test",
       "org.scalacheck"    %% "scalacheck" % versions("scalacheck") % "test"
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -18,12 +18,14 @@ lazy val pluginSettings = Seq(
     scalaVersion in ThisBuild := "2.10.6",
     resolvers ++= Seq(
       Resolver.sonatypeRepo("releases"),
+      Resolver.sonatypeRepo("snapshots"),
       "jgit-repo" at "http://download.eclipse.org/jgit/maven"
     ),
     libraryDependencies ++= Seq(
-      "org.scalactic"  %% "scalactic"  % "3.0.0",
-      "org.scalatest"  %% "scalatest"  % versions("scalatest") % "test",
-      "org.scalacheck" %% "scalacheck" % versions("scalacheck") % "test"
+      "org.scalactic"     %% "scalactic"  % "3.0.0",
+      "com.fortysevendeg" %% "github4s"   % "0.9.1-SNAPSHOT",
+      "org.scalatest"     %% "scalatest"  % versions("scalatest") % "test",
+      "org.scalacheck"    %% "scalacheck" % versions("scalacheck") % "test"
     ),
     scalafmtConfig in ThisBuild := Some(file(".scalafmt"))
   ) ++ reformatOnCompileSettings

--- a/src/main/scala/dependencies/DependenciesKeys.scala
+++ b/src/main/scala/dependencies/DependenciesKeys.scala
@@ -1,3 +1,14 @@
 package dependencies
 
-trait DependenciesKeys {}
+import sbt._
+
+trait DependenciesKeys {
+
+  val showDependencyUpdates = taskKey[Unit]("Shows the dependency updates")
+  val updateDependencyIssues =
+    taskKey[Unit]("Creates and updates issues for all dependency updates")
+
+  val githubOwner = settingKey[String]("GitHub owner")
+  val githubRepo  = settingKey[String]("GitHub repo")
+
+}

--- a/src/main/scala/dependencies/DependenciesPlugin.scala
+++ b/src/main/scala/dependencies/DependenciesPlugin.scala
@@ -2,18 +2,93 @@ package dependencies
 
 import com.timushev.sbt.updates.UpdatesPlugin.autoImport._
 import com.timushev.sbt.updates.versions.Version
+import github4s.free.domain.Issue
 import sbt.Keys._
 import sbt._
 
 import scala.collection.immutable.SortedSet
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.{Failure, Success}
 
 object DependenciesPlugin extends AutoPlugin {
 
   object autoImport extends DependenciesKeys
 
+  import DependenciesPlugin.autoImport._
+
+  def readUpdates(data: Map[ModuleID, SortedSet[Version]], log: Logger)(
+      f: (List[DependencyUpdate]) => Unit) =
+    Updates.readUpdates(data) match {
+      case Nil  => log.info("\nNo dependency updates found\n")
+      case list => f(list)
+    }
+
+  def createIssueForDep(dep: DependencyUpdate,
+                        issues: Map[String, Issue],
+                        githubClient: GithubClient,
+                        log: Logger): Future[Issue] = {
+    log.info(s"Preparing issue for module `${dep.moduleName}`\n")
+    issues.get(dep.moduleName) match {
+      case Some(issue) =>
+        log.info(s"Found existing open issue (#${issue.number}), updating it\n")
+        githubClient.updateIssue(issue, dep) map { issue =>
+          log.info(s"Issue updated at: ${issue.html_url}")
+          issue
+        }
+      case None =>
+        log.info("Existing issue not found, creating a new one\n")
+        githubClient.createIssue(dep) map { issue =>
+          log.info(s"Issue created at: ${issue.html_url}")
+          issue
+        }
+    }
+  }
+
   lazy val defaultSettings = Seq(
-    dependencyUpdatesExclusions := moduleFilter(organization = "org.scala-lang"),
-    compile <<= (compile in Compile) dependsOn dependencyUpdates
+    showDependencyUpdates := {
+      readUpdates(dependencyUpdatesData.value, streams.value.log) {
+        list =>
+          val fullTable = Seq("Module", "Revision", "Patch", "Minor", "Major") +:
+              list.map(
+                dep =>
+                  Seq(dep.moduleName,
+                      dep.revision,
+                      dep.patch.getOrElse(""),
+                      dep.minor.getOrElse(""),
+                      dep.major.getOrElse("")))
+          streams.value.log.info("\nFound some dependency updates:\n")
+          streams.value.log.info(TablePrinter.format(fullTable))
+          streams.value.log.info("Execute `updateDependencyIssues` to update your issues\n")
+      }
+    },
+    updateDependencyIssues := {
+      readUpdates(dependencyUpdatesData.value, streams.value.log) {
+        list =>
+          streams.value.log.info("Reading GitHub issues\n")
+          sys.props.get("githubToken") match {
+            case Some(accessToken) =>
+              val githubClient = GithubClient(githubOwner.value, githubRepo.value, accessToken)
+              val result = for {
+                issues <- githubClient.findIssuesByModuleName()
+                createdIssues <- Future.sequence(
+                  list map (dep =>
+                              createIssueForDep(dep, issues, githubClient, streams.value.log)))
+              } yield createdIssues
+              result onComplete {
+                case Success(createdIssues) => streams.value.log.info("GitHub issues created or updated\n")
+                case Failure(e) =>
+                  streams.value.log.error(s"Error creating issues")
+                  e.printStackTrace()
+              }
+            case None =>
+              streams.value.log.info(
+                "Can't read the access token, please set the GitHub token with the property 'githubToken' (for ex. `sbt -DgithubToken=XXXXXX`)\n")
+          }
+
+      }
+    },
+    dependencyUpdatesExclusions := moduleFilter(organization = "org.scala-lang")
   )
 
   override val projectSettings = defaultSettings

--- a/src/main/scala/dependencies/DependenciesPlugin.scala
+++ b/src/main/scala/dependencies/DependenciesPlugin.scala
@@ -49,14 +49,14 @@ object DependenciesPlugin extends AutoPlugin {
     showDependencyUpdates := {
       readUpdates(dependencyUpdatesData.value, streams.value.log) {
         list =>
-          val fullTable = Seq("Module", "Revision", "Patch", "Minor", "Major") +:
+          val fullTable = List("Module", "Revision", "Patch", "Minor", "Major") +:
               list.map(
                 dep =>
-                  Seq(dep.moduleName,
-                      dep.revision,
-                      dep.patch.getOrElse(""),
-                      dep.minor.getOrElse(""),
-                      dep.major.getOrElse("")))
+                  List(dep.moduleName,
+                       dep.revision,
+                       dep.patch.getOrElse(""),
+                       dep.minor.getOrElse(""),
+                       dep.major.getOrElse("")))
           streams.value.log.info("\nFound some dependency updates:\n")
           streams.value.log.info(TablePrinter.format(fullTable))
           streams.value.log.info("Execute `updateDependencyIssues` to update your issues\n")
@@ -76,14 +76,22 @@ object DependenciesPlugin extends AutoPlugin {
                               createIssueForDep(dep, issues, githubClient, streams.value.log)))
               } yield createdIssues
               result onComplete {
-                case Success(createdIssues) => streams.value.log.info("GitHub issues created or updated\n")
+                case Success(createdIssues) =>
+                  streams.value.log.info("GitHub issues created or updated\n")
                 case Failure(e) =>
                   streams.value.log.error(s"Error creating issues")
                   e.printStackTrace()
               }
             case None =>
               streams.value.log.info(
-                "Can't read the access token, please set the GitHub token with the property 'githubToken' (for ex. `sbt -DgithubToken=XXXXXX`)\n")
+                """
+                  | Can't read the access token, please set the GitHub token with the property 'githubToken'
+                  | (for ex. `sbt -DgithubToken=XXXXXX`)
+                  |
+                  | You can create a new token in this page:
+                  |  * https://github.com/settings/tokens
+                  |
+                  | """.stripMargin)
           }
 
       }

--- a/src/main/scala/dependencies/GithubClient.scala
+++ b/src/main/scala/dependencies/GithubClient.scala
@@ -49,9 +49,9 @@ class GithubClient(owner: String, repo: String, accessToken: String)(implicit ec
       .createIssue(owner = owner,
                    repo = repo,
                    title = title(dependencyUpdate),
-                   body = Some(body(dependencyUpdate)),
-                   labels = Some(List(issueLabel)),
-                   assignees = Some(List.empty))
+                   body = body(dependencyUpdate),
+                   labels = List(issueLabel),
+                   assignees = List.empty)
       .execFuture[HttpResponse[String]](Map("user-agent" -> "sbt-dependencies")) map {
       case Right(response) => response.result
       case Left(e)         => throw e

--- a/src/main/scala/dependencies/GithubClient.scala
+++ b/src/main/scala/dependencies/GithubClient.scala
@@ -1,0 +1,95 @@
+package dependencies
+
+import cats.MonadError
+import cats.instances.future
+import github4s.Github
+import github4s.Github._
+import github4s.jvm.Implicits._
+import github4s.free.domain._
+
+import scala.concurrent.{ExecutionContext, Future}
+import scalaj.http.HttpResponse
+
+class GithubClient(owner: String, repo: String, accessToken: String)(implicit ec: ExecutionContext) {
+
+  val issueTitle = "Update dependency"
+  val issueLabel = "update-dependencies"
+
+  implicit val monadError: MonadError[Future, Throwable] = catsStdInstancesForFuture
+
+  def findIssuesByModuleName(): Future[Map[String, Issue]] = {
+
+    def readIssues(issues: List[Issue]): Map[String, Issue] =
+      issues.flatMap { issue =>
+        if (issue.title.startsWith(issueTitle) && issue.title.length > issueTitle.length + 1) {
+          val moduleName = issue.title.substring(issueTitle.length + 1)
+          Option(moduleName -> issue)
+        } else {
+          None
+        }
+      }.toMap
+
+    val searchParams = List(OwnerParamInRepository(s"$owner/$repo"),
+                            IssueTypeIssue,
+                            IssueStateOpen,
+                            SearchIn(Set(SearchInTitle)),
+                            LabelParam(issueLabel))
+
+    Github(Some(accessToken)).issues
+      .searchIssues(issueTitle, searchParams)
+      .execFuture[HttpResponse[String]](Map("user-agent" -> "sbt-dependencies")) map {
+      case Right(response) =>
+        readIssues(response.result.items)
+      case Left(e) => throw e
+    }
+  }
+
+  def createIssue(dependencyUpdate: DependencyUpdate): Future[Issue] =
+    Github(Some(accessToken)).issues
+      .createIssue(owner = owner,
+                   repo = repo,
+                   title = title(dependencyUpdate),
+                   body = Some(body(dependencyUpdate)),
+                   labels = Some(List(issueLabel)),
+                   assignees = Some(List.empty))
+      .execFuture[HttpResponse[String]](Map("user-agent" -> "sbt-dependencies")) map {
+      case Right(response) => response.result
+      case Left(e)         => throw e
+    }
+
+  def updateIssue(issue: Issue, dependencyUpdate: DependencyUpdate): Future[Issue] =
+    Github(Some(accessToken)).issues
+      .editIssue(owner = owner,
+                 repo = repo,
+                 issue = issue.number,
+                 state = "open",
+                 title = title(dependencyUpdate),
+                 body = body(dependencyUpdate),
+                 milestone = None,
+                 labels = List(issueLabel),
+                 assignees = issue.assignee.toList.map(_.login))
+      .execFuture[HttpResponse[String]](Map("user-agent" -> "sbt-dependencies")) map {
+      case Right(response) => response.result
+      case Left(e)         => throw e
+    }
+
+  def title(dependencyUpdate: DependencyUpdate): String =
+    s"$issueTitle ${dependencyUpdate.moduleName}"
+
+  def body(dependencyUpdate: DependencyUpdate): String =
+    s"""
+       | Actual version: ${dependencyUpdate.revision}
+       | Patch: ${dependencyUpdate.patch.getOrElse("-")}
+       | Minor: ${dependencyUpdate.minor.getOrElse("-")}
+       | Major: ${dependencyUpdate.major.getOrElse("-")}
+         """.stripMargin
+
+}
+
+object GithubClient {
+
+  def apply(owner: String, repo: String, accessToken: String)(
+      implicit ec: ExecutionContext): GithubClient =
+    new GithubClient(owner, repo, accessToken)
+
+}

--- a/src/main/scala/dependencies/Model.scala
+++ b/src/main/scala/dependencies/Model.scala
@@ -1,0 +1,7 @@
+package dependencies
+
+case class DependencyUpdate(moduleName: String,
+                            revision: String,
+                            patch: Option[String],
+                            minor: Option[String],
+                            major: Option[String])

--- a/src/main/scala/dependencies/TablePrinter.scala
+++ b/src/main/scala/dependencies/TablePrinter.scala
@@ -1,0 +1,38 @@
+package dependencies
+
+object TablePrinter {
+
+  def format(table: Seq[Seq[String]]) = table match {
+    case Seq() => ""
+    case _ =>
+      val sizes = table map {
+        _.map { cell =>
+          Option(cell) map (_.length) getOrElse 0
+        }
+      }
+      val colSizes = sizes.transpose map (_.max)
+      val rows = table.zipWithIndex.map {
+        case (row, index) => formatRow(row, colSizes, index == 0)
+      }
+      formatRows(rowSeparator(colSizes), rows)
+  }
+
+  def formatRows(rowSeparator: String, rows: Seq[String]): String =
+    (rowSeparator ::
+      rows.head ::
+        rowSeparator ::
+          rows.tail.toList :::
+            rowSeparator ::
+              List()).mkString("\n")
+
+  def formatRow(row: Seq[String], colSizes: Seq[Int], header: Boolean) = {
+    val cells = row.zip(colSizes) map {
+      case (item, size) if size == 0 => ""
+      case (item, size)              => ("%" + size + "s").format(item)
+    }
+    cells.mkString("|", "|", "|")
+  }
+
+  def rowSeparator(colSizes: Seq[Int]) = colSizes map { "-" * _ } mkString ("+", "+", "+")
+
+}

--- a/src/main/scala/dependencies/TablePrinter.scala
+++ b/src/main/scala/dependencies/TablePrinter.scala
@@ -2,8 +2,8 @@ package dependencies
 
 object TablePrinter {
 
-  def format(table: Seq[Seq[String]]) = table match {
-    case Seq() => ""
+  def format(table: List[List[String]]) = table match {
+    case Nil => ""
     case _ =>
       val sizes = table map {
         _.map { cell =>
@@ -17,15 +17,15 @@ object TablePrinter {
       formatRows(rowSeparator(colSizes), rows)
   }
 
-  def formatRows(rowSeparator: String, rows: Seq[String]): String =
+  def formatRows(rowSeparator: String, rows: List[String]): String =
     (rowSeparator ::
       rows.head ::
         rowSeparator ::
-          rows.tail.toList :::
+          rows.tail :::
             rowSeparator ::
               List()).mkString("\n")
 
-  def formatRow(row: Seq[String], colSizes: Seq[Int], header: Boolean) = {
+  def formatRow(row: List[String], colSizes: List[Int], header: Boolean) = {
     val cells = row.zip(colSizes) map {
       case (item, size) if size == 0 => ""
       case (item, size)              => ("%" + size + "s").format(item)
@@ -33,6 +33,6 @@ object TablePrinter {
     cells.mkString("|", "|", "|")
   }
 
-  def rowSeparator(colSizes: Seq[Int]) = colSizes map { "-" * _ } mkString ("+", "+", "+")
+  def rowSeparator(colSizes: List[Int]) = colSizes map { "-" * _ } mkString ("+", "+", "+")
 
 }

--- a/src/main/scala/dependencies/Updates.scala
+++ b/src/main/scala/dependencies/Updates.scala
@@ -1,0 +1,41 @@
+package dependencies
+
+import com.timushev.sbt.updates.versions.Version
+import sbt.ModuleID
+
+import scala.collection.immutable.SortedSet
+
+object Updates {
+
+  def formatModule(module: ModuleID) =
+    module.organization + ":" + module.name + module.configurations.map(":" + _).getOrElse("")
+
+  def patchUpdate(c: Version, updates: SortedSet[Version]) =
+    updates.filter { v =>
+      v.major == c.major && v.minor == c.minor
+    }.lastOption
+
+  def minorUpdate(c: Version, updates: SortedSet[Version]) =
+    updates.filter { v =>
+      v.major == c.major && v.minor > c.minor
+    }.lastOption
+
+  def majorUpdate(c: Version, updates: SortedSet[Version]) =
+    updates.filter { v =>
+      v.major > c.major
+    }.lastOption
+
+  def readUpdates(data: Map[ModuleID, SortedSet[Version]]): List[DependencyUpdate] =
+    data.map {
+      case (m, vs) =>
+        val c = Version(m.revision)
+        DependencyUpdate(
+          moduleName = formatModule(m),
+          revision = m.revision,
+          patch = patchUpdate(c, vs).map(_.toString),
+          minor = minorUpdate(c, vs).map(_.toString),
+          major = majorUpdate(c, vs).map(_.toString)
+        )
+    }.toList.sortBy(_.moduleName)
+
+}


### PR DESCRIPTION
This PR adds some basic functionality to the plugin.

It includes two tasks:
- `showDependencyUpdates`: Prints a table with all possible dependency updates
- `updateDependencyIssues`: Creates and updates issues for all dependency updates

I've created a sample repo to test the functionality, you just need to publish locally this plugin and test it with the project [sbt-dependencies-tests](https://github.com/47deg/sbt-dependencies-tests)

Bear in mind that it's a very basic implementation, there are a lot of pending tasks like using another monad for the execution, microsite, tests, ...

Please @raulraja @juanpedromoreno could you review? Thanks