### PR TITLE
Release 0.3.1

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.7.0")
+addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.7.1")
 
 libraryDependencies += {
   lazy val sbtVersionValue = (sbtVersion in pluginCrossBuild).value

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.3.1-SNAPSHOT"
+version in ThisBuild := "0.3.1"


### PR DESCRIPTION
Bump sbt-org-policies to 0.7.1.

Fixes the `publishMicrosite` failure in Travis.

This build will fail until https://github.com/47deg/sbt-org-policies/pull/634 gets merged and the artifacts gets propagated.